### PR TITLE
Fix to rdr2geo functionalities

### DIFF
--- a/defaults/cslc_s1.yaml
+++ b/defaults/cslc_s1.yaml
@@ -37,12 +37,10 @@ runconfig:
            product_type: CSLC_S1
 
        processing:
+           polarization: HH
            rdr2geo:
                lines_per_block: 1000
-
            geo2rdr:
                lines_per_block: 1000
-
            resample:
                lines_per_block: 1000
-

--- a/schemas/cslc_s1.yaml
+++ b/schemas/cslc_s1.yaml
@@ -34,18 +34,15 @@ runconfig:
         # This section includes parameters to tweak the workflow
         processing:
            # Polarization to process. If not set, process all polarizations for that burst
-           polarization: any(list('HH', 'HV', 'VH', 'VV'), min=1, max=4), str(min=2, max=2), required=False)
-
+           polarization: any(list('HH', 'HV', 'VH', 'VV'), min=1, max=4, required=False)
            # Options to run rdr2geo
            rdr2geo: include('rdr2geo_options', required=False)
-
            # Options to run geo2rdr
-           geo2rdr: include('rdr2geo_geo2rdr_shared_options', required=False)
-
+           geo2rdr: include('geo2rdr_options', required=False)
            # Options to run resample
            resample: include('resample_options', required=False)
 
-
+---
 # Group of processing options
 reference_burst_options:
     # Required. Flag indicating reference burst.
@@ -55,7 +52,7 @@ reference_burst_options:
     # Only used if the flag is_reference is set to False.
     file_path: str(required=False)
 
-rdr2geo_geo2rdr_shared_options:
+geo2rdr_options:
    # Convergence threshold for rdr2geo algorithm
    threshold: num(min=0, required=False)
    # Maximum number of iterations
@@ -64,13 +61,15 @@ rdr2geo_geo2rdr_shared_options:
    lines_per_block: int(min=1, required=False)
 
 rdr2geo_options:
-   # rdr2geo and geo2rdr shared options
-   include('rdr2geo_geo2rdr_shared_options', required=False)
+   # Convergence threshold for rdr2geo algorithm
+   threshold: num(min=0, required=False)
+   # Maximum number of iterations
+   numiter: int(min=1, required=False)
+   # Lines per block to process in batch
+   lines_per_block: int(min=1, required=False)
    # Secondary number of iterations
    extraiter: int(min=1, required=False)
 
 resample_options:
    # Lines per block to process in batch
    lines_per_block: int(min=1, required=False)
-
-

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,0 +1,95 @@
+'''
+Suite of functionalities used across the CSLC workflow
+'''
+
+import logging
+import os
+
+from osgeo import gdal
+
+WORKFLOW_SCRIPTS_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def check_file_path(file_path: str) -> None:
+    """Check if file_path exist. If not, raise an error
+       Parameters
+       ----------
+       file_path: str
+         Path to file to be checked
+    """
+    if not os.path.isfile(file_path):
+        err_str = f'{file_path} not found'
+        logging.error(err_str)
+        raise FileNotFoundError(err_str)
+
+
+def deep_update(original: dict, update: dict):
+    """Update default runconfig with user-supplied options
+       Parameters
+       ----------
+       original: dict
+         Dictionary with default options to be updated
+       update: dict
+         Dictionary with user-supplied options used as update
+
+       Returns
+       -------
+       original: dict
+         "original" dictionary updated with user options
+
+       Reference
+       ---------
+       https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
+    """
+    for key, val in update.items():
+        if isinstance(val, dict):
+            original[key] = deep_update(original.get(key, {}), val)
+        else:
+            original[key] = val
+
+    # return updated original
+    return original
+
+
+def check_write_dir(dst_path: str):
+    """Check if dst_path exists and is writeable. Raise error if not.
+       Parameters
+       ----------
+       dst_path: str
+          File path to directory to be checked
+    """
+    if not dst_path:
+        dst_path = '.'
+
+    # Check if dst_path exists
+    dst_path_ok = os.path.isdir(dst_path)
+
+    if not dst_path_ok:
+        try:
+            os.makedirs(dst_path, exist_ok=True)
+        except OSError:
+            err_str = f"Unable to create directory {dst_path}"
+            logging.error(err_str)
+            raise OSError(err_str)
+
+    # check if path writeable
+    write_ok = os.access(dst_path, os.W_OK)
+    if not write_ok:
+        err_str = f"{dst_path} scratch directory lacks write permission."
+        logging.error(err_str)
+        raise PermissionError(err_str)
+
+
+def check_dem(dem_path: str):
+    """Check if DEM exists. DEM must be a GDAL-compatible raster
+       Parameters
+       ----------
+       dem_path: str
+         File path to DEM file to be checked
+    """
+    try:
+        gdal.Open(dem_path)
+    except ValueError:
+        err_str = f'{dem_path} cannot be opened by GDAL'
+        logging.error(err_str)
+        raise ValueError(err_str)

--- a/src/runconfig.py
+++ b/src/runconfig.py
@@ -1,0 +1,170 @@
+import logging
+import os
+from dataclasses import dataclass
+
+import yamale
+from ruamel.yaml import YAML
+
+import helpers
+
+
+def check_runconfig(runconfig_cfg: dict) -> None:
+    """Check input validity of runconfig entries.
+       Parameters
+       ----------
+       cfg: dict
+        Dictionary containing runconfig parameters
+    """
+
+    # Check runconfig entries in 'input_file_group'
+    input_group = runconfig_cfg['input_file_group']
+
+    is_reference = input_group['reference_burst']['is_reference']
+    # If not processing reference, check that reference burst is provided
+    if not is_reference:
+        helpers.check_file_path(input_group['reference_burst']['file_path'])
+
+    # If 'is_reference' is True, ensure only one SAFE file is provided
+    # as reference
+    for i, safe_file in enumerate(input_group['safe_file_path']):
+        if is_reference and i > 0:
+            err_str = 'Multiple SAFE files provided as reference'
+            logging.error(err_str)
+            raise ValueError(err_str)
+        # Check that provided SAFE files exists
+        helpers.check_file_path(safe_file)
+
+    # Check that provided orbit files exist
+    helpers.check_file_path(input_group['orbit_file_path'])
+
+    # Check entries in Dynamic Ancillary File group
+    # Check DEM file exists and is GDAL-compatible
+    dem_path = runconfig_cfg['dynamic_ancillary_file_groups']['dem_file']
+    helpers.check_file_path(dem_path)
+    helpers.check_dem(dem_path)
+
+    # Check Product Path group.
+    product_path_group = runconfig_cfg['product_path_group']
+    helpers.check_write_dir(product_path_group['product_path'])
+    helpers.check_write_dir(product_path_group['scratch_path'])
+    helpers.check_file_path(product_path_group['sas_output_file'])
+
+    # Check polarization to process. If entry is not provided,
+    # process the most common used polarizations
+    if 'polarization' not in runconfig_cfg['processing']:
+        runconfig_cfg['processing']['polarization'] = ['HH', 'HV']
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    """Class storing runconfig entries"""
+    name: str
+    # for easy immutability, lazily keep dict read from yaml (for now?)
+    groups: dict
+
+    @classmethod
+    def load_from_yaml(cls, yaml_path: str, workflow_name: str) -> RunConfig:
+        """Initialize runconfig using user-provided YAML file
+           Parameters
+           ----------
+           yaml_path: str
+             File path to YAML file
+           workflow_name: str
+             Name of the workflow for which to build YAML file
+
+           Returns:
+           -------
+        """
+        # Upload schema for YAML file validation
+        try:
+            schema = yamale.make_schema(
+                f'{helpers.WORKFLOW_SCRIPTS_DIR}/schemas/{workflow_name}.yaml',
+                parser='ruamel')
+        except ValueError:
+            err_str = f'Unable to load schema for workflow {workflow_name}.'
+            logging.error(err_str)
+            raise ValueError(err_str)
+
+        # Load user-provided YAML file
+        if os.path.isfile(yaml_path):
+            try:
+                data = yamale.make_data(yaml_path, parser='ruamel')
+            except yamale.YamaleError as yamale_err:
+                err_str = f'Unable to load {workflow_name} yaml ' \
+                          f'runconfig {yaml_path} for validation.'
+                logging.error(err_str)
+                raise yamale.YamaleError(err_str) from yamale_err
+        else:
+            raise FileNotFoundError
+
+        # validate yaml file taken from command line
+        try:
+            yamale.validate(schema, data)
+        except yamale.YamaleError as yamale_err:
+            err_str = f'Validation fail for {workflow_name} ' \
+                      f'runconfig yaml {yaml_path}.'
+            logging.error(err_str)
+            raise yamale.YamaleError(err_str) from yamale_err
+
+        # Load default runconfig
+        parser = YAML(typ='safe')
+        default_cfg_path = f'{helpers.WORKFLOW_SCRIPTS_DIR}/' \
+                           f'defaults/{workflow_name}.yaml'
+        with open(default_cfg_path, 'r') as f_default:
+            default_cfg = parser.load(f_default)
+        # Load user-provided runconfig
+        with open(yaml_path, 'r') as f_yaml:
+            user_cfg = parser.load(f_yaml)
+
+        # Copy user-supplied options in default runconfig
+        helpers.deep_update(default_cfg, user_cfg)
+
+        # Check the validity of runconfig groups and entries
+        check_runconfig(default_cfg['groups'])
+
+        return cls(default_cfg['name'], default_cfg['groups'])
+
+    @property
+    def burst_id(self) -> list[str]:
+        return self.groups['input_file_group']['burst_id']
+
+    @property
+    def dem(self) -> str:
+        return self.groups['dynamic_ancillary_file_groups']['dem_file']
+
+    @property
+    def is_reference(self) -> bool:
+        return self.groups['input_file_group']['reference_burst'][
+            'is_reference']
+
+    @property
+    def orbit_path(self) -> bool:
+        return self.groups['input_file_group']['orbit_file_path']
+
+    @property
+    def polarization(self) -> list[str]:
+        return self.groups['processing']['polarization']
+
+    @property
+    def product_path(self):
+        return self.groups['product_path_group']['product_path']
+
+    @property
+    def reference_path(self) -> str:
+        return self.groups['reference_burst']['file_path']
+
+    @property
+    def rdr2geo_params(self) -> dict:
+        return self.groups['processing']['rdr2geo']
+
+    @property
+    def safe_files(self) -> list[str]:
+        return self.groups['input_file_group']['safe_file_path']
+
+    @property
+    def sas_output_file(self):
+        return self.groups['product_path_group']['sas_output_file']
+
+    @property
+    def scratch_path(self):
+        return self.groups['product_path_group']['scratch_path']


### PR DESCRIPTION
This PR fixes some issue with the initial implementation of the `rdr2geo` workflow. It mainly acts on the following functionalities: `helpers.py`, `runconfig.py`. 
Issues with rdr2geo.py and testing will be addressed in subsequent PRs.

**A summary of the added fixes**:

1. To enable the `include` parts, the schema needs to have `---` before the set of include options
2. Inconsistent use of `logging` and `journal`. For logging error and info messages. At the moment, this has been changed to `logging` but probably it would be easier to switch to `journal` (since `isce3` is a dependency).
3. Added docstring documentation to the several functions

`NOTE:`
I am not convinced that `helpers.py` and `runconfig.py` should go in src. I was thinking of having a repo for the workflows (named `workflows`) and one for utilities (named `utils`). What do you think? I'd like to have more separation of functionalities. 
